### PR TITLE
User permissions

### DIFF
--- a/app/controllers/cruises_controller.rb
+++ b/app/controllers/cruises_controller.rb
@@ -1,10 +1,11 @@
 class CruisesController < ApplicationController
-  authorize_resource
-
   before_action :set_cruise, only: [:show, :edit, :update, :destroy, :approve, :reject]
   before_action :set_active_cruise, only: [:index, :show]
   before_action :set_observations, only: [:show]
   before_action :set_current_year, only: [:index]
+
+  authorize_resource
+
   # respond_to :geojson, :json, :csv, :zip
   # GET /cruises
   # GET /cruises.json

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -80,10 +80,11 @@ class ObservationsController < ApplicationController
   # PATCH/PUT /observations/1.json
   def update
     @observation.assign_attributes observation_params
+    @cruise = Cruise.find @observation.cruise_id
     respond_to do |format|
       if @observation.save(validate: false)
-        if params[:commit] == 'Save and Exit'
-          format.html { redirect_to root_url }
+	if params[:commit] == 'Save and Exit'
+          format.html { redirect_to cruise_url(@cruise), notice: 'Observation was successfully updated.' }
         else
           format.html { redirect_to edit_observation_path(@observation), notice: 'Observation was successfully updated.' }
         end

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1,8 +1,7 @@
 require "rubypython"
 class ObservationsController < ApplicationController
-  authorize_resource except: [:aspect]
-
   before_action :set_observation, only: [:show, :edit, :update, :destroy]
+  authorize_resource except: [:aspect]
 
   # GET /observations
   # GET /observations.json

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -37,7 +37,9 @@ class Ability
       can :import, Observation, cruise_id: user_cruises(user)
       can :read, Cruise, approved: true
       can :read, Cruise, id: user_cruises(user)
-      can %i(create read update delete), Observation, cruise_id: user_cruises(user)
+      can [:edit, :update, :destroy], Cruise, approved: nil, id: user_cruises(user)
+      can :read, Observation, cruise_id: user_cruises(user)
+      can [:edit, :update, :destroy], Observation, status: 'saved', cruise_id: user_cruises(user)
       can :read, User, id: user.id
       can :create, UploadedFile, cruise_id: user_cruises(user)
       # Members can create cruises

--- a/app/views/cruises/_observation.html.haml
+++ b/app/views/cruises/_observation.html.haml
@@ -13,7 +13,7 @@
         - if can?(:edit, Observation)
           = link_to edit_observation_path(observation), class: 'btn btn-xsm btn-default' do
             %i.fa.fa-edit
-        - if can?(:delete, Observation)
+        - if can?(:destroy, Observation)
           = link_to observation_path(observation), method: :delete,
             data: {confirm: 'This will permanently remove this observation'},
             class: 'btn btn-xsm btn-danger' do

--- a/app/views/cruises/_sidebar_approve.html.haml
+++ b/app/views/cruises/_sidebar_approve.html.haml
@@ -4,6 +4,12 @@
       %i.fa.fa-thumbs-up
       Approve Cruise
 
+- if can?(:update, Cruise) && !@cruise.approved?
+  %li.list-group-item
+    = link_to edit_cruise_path(@cruise), method: :get do
+      %i.fa.fa-edit
+      Edit Cruise Metadata
+
 - if can?(:approve, Observation) && @cruise.approved?
   %li.list-group-item
     = link_to approve_observations_cruise_path(@cruise), method: :post do

--- a/app/views/observations/_form.html.haml
+++ b/app/views/observations/_form.html.haml
@@ -16,7 +16,7 @@
       %br
       = f.submit 'Save', class: 'btn btn-block btn-success'
       = f.submit 'Save and Exit', class: 'btn btn-block btn-warning'
-      = link_to 'Exit without Saving', root_path,
+      = link_to 'Exit without Saving', cruise_url(@observation.cruise_id),
                 class: 'btn btn-block btn-danger',
                 data: {confirm: 'Any changes made will be lost'}
     .col-md-10.col-sm-9

--- a/test/controllers/observations_controller_test.rb
+++ b/test/controllers/observations_controller_test.rb
@@ -17,6 +17,8 @@ class ObservationsControllerTest < ActionController::TestCase
   end
 
   test 'should show observation' do
+    login_user(users(:admin))
+
     get :show, id: @observation
     assert_response :success
   end


### PR DESCRIPTION
- Fix loophole in user permissions
- Ensure users can actually delete observations
- Redirect back to cruise page after editing observation
- Allow users to edit metadata of unapproved cruises they own